### PR TITLE
changed background color of input on messages screen

### DIFF
--- a/src/components/SendMessageForm/styles.js
+++ b/src/components/SendMessageForm/styles.js
@@ -13,6 +13,7 @@ export default makeStyles((theme) => ({
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'flex-end',
+        backgroundColor: theme.palette.background.default
     },
     sendMessageInputLabel: {
         paddingTop: 6,


### PR DESCRIPTION
Adds a solid background around the TextField on the Messages screen so the messages don't directly hit the outlined input