### PR TITLE
fixed notification showing the wrong sender in the title

### DIFF
--- a/src/modules/localNotifications.js
+++ b/src/modules/localNotifications.js
@@ -18,9 +18,12 @@ export const createNotificationChannel = async (specData) => {
 }
 
 export const scheduleLocalNotification = async (data, view) => {
+    const dateOfLastMessage = new Date(Math.max(...data.map(e => new Date(e.lastMessageRecieved)))).toISOString()
+    const latestMessageContact = data.find(contact => contact.lastMessageRecieved === dateOfLastMessage && contact)
+
     if (!isWeb) {
         let specData;
-        view === 'contacts' ? specData = data[data.length - 1] : specData = data
+        view === 'contacts' ? specData = latestMessageContact : specData = data
 
         BackgroundMode.isScreenOff(async off => {
             console.log('isScreenOff > off:', off)


### PR DESCRIPTION
Fixes the bug where the notification was showing the wrong contact info. i was originally under the assumption the order of the contacts array that got passed mutated to have the latest message as the last entry. now it takes the date of the lastRecievedMessage and finds the contact in the array that matches and passes the info