### PR TITLE
moved drop tables button inside Grid item

### DIFF
--- a/src/components/Forms/SettingsForm.jsx
+++ b/src/components/Forms/SettingsForm.jsx
@@ -197,7 +197,11 @@ const SettingsForm = ({ closeDialog }) => {
                     </Grid>
 
                     <Divider />
-                    <DestroyContent />
+
+                    <Grid item>
+                        <DestroyContent />
+                    </Grid>
+                    
                 </Grid>
             </DialogContent>
         </form>


### PR DESCRIPTION
moved the button to clear database inside a Grid item so it's not so close to the switches